### PR TITLE
Fix incorrect instruction in README

### DIFF
--- a/exercises/sinatra-katas/README.md
+++ b/exercises/sinatra-katas/README.md
@@ -3,7 +3,7 @@
 You can run this application from your application's root directory (rember to run ```bundle install```)
 
 ```bash
-rerun -x rackup
+rerun -c rackup
 ```
 
 View the application in browser ```http://locahost:9292/```.


### PR DESCRIPTION
Using the `-x` flag with `rerun` will expect the process to exit. This doesn't make much sense in the context of running a web server. Instead, instruct to use the flag `-c` to clear the screen on each reload.
